### PR TITLE
Remove trailing whitespace.

### DIFF
--- a/FAQ-xml2rfcv3.xml
+++ b/FAQ-xml2rfcv3.xml
@@ -4,7 +4,7 @@
 ]>
 
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" obsoletes="" updates=""
-     docName="FAQ-xml2rfcv3-06" submissionType="IETF" category="info" xml:lang="en" version="3" 
+     docName="FAQ-xml2rfcv3-06" submissionType="IETF" category="info" xml:lang="en" version="3"
      ipr="none" tocInclude="true" consensus="no" symRefs="true" sortRefs="true">
   <!-- xml2rfc v2v3 conversion 2.17.0 -->
   <!-- intend for the HTML output to be read, not the text output -->
@@ -68,7 +68,7 @@ extraction.  Also, the RFC Editor will make use of your source file.
       <section numbered="true" toc="default">
         <name>How much XML do I need to know?</name>
         <t>
-You need the essentials. XML uses start and end tags, which are 
+You need the essentials. XML uses start and end tags, which are
 nested and matching, and they are case-sensitive. See
 "XML basics" in <xref target="howto" format="title"/> for
 more details.
@@ -172,8 +172,8 @@ For example, putting it together:
    category="info"
    submissionType="IETF"
    ipr="trust200902"
-   docName="draft-ietf-wgname-topic-00" 
-   updates="1234, 1235" 
+   docName="draft-ietf-wgname-topic-00"
+   updates="1234, 1235"
    obsoletes="1236"
    sortRefs="true">
 ]]></sourcecode>
@@ -182,7 +182,7 @@ For example, putting it together:
 	  Note: The attributes number and seriesNo will be added by the RFC Editor
 	  if your draft is approved for publication as an RFC.
 	</t>
-	
+
 	<t>
 	  Note: Some features that used to be processing instructions (in v2)
 	  are now attributes of the rfc element (in v3) -- for
@@ -206,7 +206,7 @@ RFCs, Internet-Drafts, and documents produced by the W3C and 3GPP, among
 others.
 </t>
         <t>
-To make use of the citation libraries, use an xi:include in the references 
+To make use of the citation libraries, use an xi:include in the references
 section as follows.
 </t>
             <sourcecode type="xml"><![CDATA[
@@ -299,7 +299,7 @@ yields:
 
 <dl>
 <dt><strong>[IKEv2]</strong></dt>
-<dd>Kaufman, C., Hoffman, P., Nir, Y., Eronen, P., and T. Kivinen, "Internet Key Exchange Protocol Version 2 (IKEv2)", STD 79, RFC 7296, DOI 10.17487/RFC7296, October 2014,  &lt;<eref target="https://www.rfc-editor.org/info/rfc7296"/>&gt;. 
+<dd>Kaufman, C., Hoffman, P., Nir, Y., Eronen, P., and T. Kivinen, "Internet Key Exchange Protocol Version 2 (IKEv2)", STD 79, RFC 7296, DOI 10.17487/RFC7296, October 2014,  &lt;<eref target="https://www.rfc-editor.org/info/rfc7296"/>&gt;.
 </dd>
 </dl>
       </section>
@@ -320,7 +320,7 @@ The eref element for an external reference creates a link in the HTML output.  F
         <sourcecode type="xml"><![CDATA[
 <eref target="https://www.w3.org">
 ]]></sourcecode>
-        
+
 <t>
 yields <eref target="https://www.w3.org"/>.</t>
 
@@ -346,7 +346,7 @@ Another option is using xref and creating a reference that uses the target attri
 yields
 	</t>
 <artwork><![CDATA[
-[W3C]     "World Wide Web Consortium (W3C)", <https://www.w3.org/>. 
+[W3C]     "World Wide Web Consortium (W3C)", <https://www.w3.org/>.
 ]]></artwork>
       </section>
 
@@ -377,7 +377,7 @@ Use &lt;referencegroup&gt; with an xi:include for each RFC inside of it:
 </t>
         <sourcecode type="xml"><![CDATA[
 <referencegroup anchor="STD78" target="https://www.rfc-editor.org/info/std78">
-  <xi:include 
+  <xi:include
    href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5343.xml"/>
   <xi:include
    href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5590.xml"/>
@@ -442,7 +442,7 @@ which yields
 	or How do I link to a section in another RFC?</name>
 
         <t>
-Use &lt;xref&gt; and set the sectionFormat attribute to various options. 
+Use &lt;xref&gt; and set the sectionFormat attribute to various options.
 </t>
 
 <dl newline="true">
@@ -494,7 +494,7 @@ Use &lt;xref&gt; and set the sectionFormat attribute to various options.
       <section numbered="true" toc="default">
         <name>How do I link to multiple sections within a document (e.g., 'see Sections 3 and 4')?</name>
         <t>
-Use &lt;xref&gt; with the format attribute.  For example, assuming the anchors 
+Use &lt;xref&gt; with the format attribute.  For example, assuming the anchors
 for the relevant sections match the targets:
 
 </t>
@@ -532,15 +532,15 @@ See <xref target="s_using_refs" format="title" /> and <xref target="s_using_list
 <t>Use &lt;xref&gt; with sectionFormat="bare". For example:</t>
         <sourcecode type="xml"><![CDATA[
 See Sections <xref target="RFC3550" section="5" sectionFormat="bare" /> and
-<xref target="RFC3550" section="6" sectionFormat="bare" /> in 
+<xref target="RFC3550" section="6" sectionFormat="bare" /> in
 <xref target="RFC3550"/>.
 ]]></sourcecode>
         <t>
 yields the output:
 </t>
 <blockquote><t>
-See Sections <xref target="RFC3550" section="5" sectionFormat="bare" /> 
-and <xref target="RFC3550" section="6" sectionFormat="bare" /> in 
+See Sections <xref target="RFC3550" section="5" sectionFormat="bare" />
+and <xref target="RFC3550" section="6" sectionFormat="bare" /> in
 <xref target="RFC3550"/>.
       </t></blockquote>
 
@@ -659,7 +659,7 @@ Set the group attribute to the same value for each &lt;ol&gt; element. For examp
         <name>How do I get indentation? or How do I use definition lists?</name>
         <t>
 Use a &lt;dl&gt; element (definition list), where each &lt;dt&gt; (term) in
-has a corresponding &lt;dd&gt; (description). 
+has a corresponding &lt;dd&gt; (description).
 </t>
 
 <t>
@@ -670,7 +670,7 @@ For example:</t>
   <dt>Unassigned:</dt>
   <dd>Unused and available for assignment via
   documented procedures.</dd>
-  
+
   <dt>Reserved:</dt>
   <dd>Not to be assigned.  Reserved values are
   held for special uses, such as to extend the namespace
@@ -685,7 +685,7 @@ For example:</t>
   <dt>Unassigned:</dt>
   <dd>Unused and available for assignment via
   documented procedures.</dd>
-  
+
   <dt>Reserved:</dt>
   <dd>Not to be assigned.  Reserved values are
   held for special uses, such as to extend the namespace
@@ -704,7 +704,7 @@ break after the term. For example:</t>
   <dt>Unassigned:</dt>
   <dd>Unused and available for assignment via
   documented procedures.</dd>
-  
+
   <dt>Reserved:</dt>
   <dd>Not to be assigned.  Reserved values are
   held for special uses, such as to extend the namespace
@@ -719,7 +719,7 @@ break after the term. For example:</t>
   <dt>Unassigned:</dt>
   <dd>Unused and available for assignment via
   documented procedures.</dd>
-  
+
   <dt>Reserved:</dt>
   <dd>Not to be assigned.  Reserved values are
   held for special uses, such as to extend the namespace
@@ -770,7 +770,7 @@ In addition, the following entities are defined:
         <name>How do I put a line break into the title of the document?</name>
         <t>
 Insert &amp;nbsp; (non-breaking space) between words that you want to keep
-together on a line. 
+together on a line.
 </t>
       </section>
 -->
@@ -790,7 +790,7 @@ Use the role attribute of the author element. For example:
       <section numbered="true" toc="default">
         <name>How do I insert questions for my coauthors?</name>
         <t>
-	  You can use comments &lt;!-- --&gt; or &lt;cref&gt; elements.  
+	  You can use comments &lt;!-- --&gt; or &lt;cref&gt; elements.
 	  Comments are only visible in the XML source file.
 	</t>
 	<t>
@@ -826,7 +826,7 @@ Example of using &lt;cref&gt;:
         <name>How do I know if my XML is valid?</name>
         <t>xml2rfc validates it.
 Also, you can run rfclint: <eref target="https://pypi.org/project/rfclint/"/>.
-	</t> 
+	</t>
       </section>
 
       <section anchor="q_HTMLoutput" numbered="true" toc="default">
@@ -886,7 +886,7 @@ service on <eref target="https://xml2rfc.tools.ietf.org/"/>.
 
       <t>You may want to do the following (for the sake of generating good
       output and having a semantically accurate XML file):</t>
-      
+
       <ul>
 	<li><t>Review each list.</t>
 	<ul>
@@ -895,20 +895,20 @@ service on <eref target="https://xml2rfc.tools.ietf.org/"/>.
 	  <li>If so, should it be <![CDATA[<dl>, <ul>, or <ol>]]>? See <xref target="s_using_lists"/>.</li>
 	</ul>
 	</li>
-	
+
 	<li><t>Review each <![CDATA[<artwork>]]>.</t>
 	<ul>
 	  <li>Should it be <![CDATA[<sourcecode>]]>? If so, what type? See <xref target="q_sourcecode"/>.</li>
 	  <li>Should it be a table? See <xref target="q_table"/>.</li>
 	</ul>
 	</li>
-	
+
 <li>Search for URLs; should these be &lt;eref&gt;? See <xref target="q_using_eref"/>.</li>
 
 <li>Look for equations or other text where new features may improve
 clarity. See <xref target="q_new_features"/>.</li>
 
-<li>Search for hardcoded citation tags (e.g., [RFC5234]) and update to 
+<li>Search for hardcoded citation tags (e.g., [RFC5234]) and update to
 &lt;xref&gt;s. See <xref target="q_add_reference"/>.</li>
 
 <li>Search for "section" and make a link for any section number in RFCs and
@@ -922,8 +922,8 @@ I-Ds (using &lt;xref&gt; with section and sectionFormat attributes). See <xref
 
       <section anchor="q_new_features" numbered="true" toc="default">
 	<name>What are the new features with v3?</name>
-	<t>Some highlights are including Unicode characters, 
-	text formatting, and SVG diagrams. For complete details, see <xref target="RFC7991" sectionFormat="of" section="1.3"/>. 
+	<t>Some highlights are including Unicode characters,
+	text formatting, and SVG diagrams. For complete details, see <xref target="RFC7991" sectionFormat="of" section="1.3"/>.
 	</t>
       </section>
 
@@ -934,7 +934,7 @@ characters in the following locations:
 </t>
 <ul>
 <li>author name and organization (fullname, initials, and surname attributes;
-organization element). The asciiFullname,                     
+organization element). The asciiFullname,
 asciiInitials, and asciiSurnames attributes hold the ASCII equivalents.</li>
 <li>author's postal address  (street, city, region, code, and country elements)
 and author's email address. Each of these elements has an <tt>ascii</tt>
@@ -1022,7 +1022,7 @@ the <u format="{lit} character ({num})">水</u>
       <td align="center">Minneapolis</td>
       <td align="center">1133</td>
     </tr>
-    <tr> 
+    <tr>
       <td align="center">63</td>
       <td align="center">Paris</td>
       <td align="center">1450</td>
@@ -1052,7 +1052,7 @@ the <u format="{lit} character ({num})">水</u>
       <td align="center">Minneapolis</td>
       <td align="center">1133</td>
     </tr>
-    <tr> 
+    <tr>
       <td align="center">63</td>
       <td align="center">Paris</td>
       <td align="center">1450</td>
@@ -1147,8 +1147,8 @@ in the text output) by using the &lt;artset&gt; element. For example:</t>
     <artwork alt="TCP Header" type="svg" src="https://www.rfc-editor.org/materials/format/svg/tcp-header.svg"/>
     <artwork alt="TCP Header from RFC 793" type="ascii-art">
       <![CDATA[
-    0                   1                   2                   3   
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |          Source Port          |       Destination Port        |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1179,7 +1179,7 @@ in the text output) by using the &lt;artset&gt; element. For example:</t>
 &lt;em&gt; for <em>italics</em>,
 </li>
 <li>
-&lt;strong&gt; for <strong>bold</strong>, and 
+&lt;strong&gt; for <strong>bold</strong>, and
 </li>
 <li>
 &lt;tt&gt; for <tt>fixed-width font</tt>.
@@ -1207,7 +1207,7 @@ asterisks around the text, and &lt;tt&gt; yields quotation marks.</t></aside>
    x<sub>3</sub> = (floor(y / 2<sup>24</sup>) + i) mod 2<sup>8</sup>
 </li>
 </ul>
-<!-- Original 
+<!-- Original
    o  x0 = (y + i) mod 2^^8
 
    o  x1 = (floor(y / 2^^8) + i) mod 2^^8


### PR DESCRIPTION
This is a really trivial change, but it stops me from having to strip out irrelevant changes my editor introduces.